### PR TITLE
feat(homepage): display latest episodes

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,3 @@
-<main>
+<main class="container">
   <router-outlet></router-outlet>
 </main>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { HeaderComponent } from './shared/header/header.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, HeaderComponent],
   templateUrl: './app.component.html',
-  styleUrl: './app.component.scss'
+  styleUrl: './app.component.scss',
 })
 export class AppComponent {
   title = 'podcast-web-app';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,9 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { HeaderComponent } from './shared/header/header.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, HeaderComponent],
+  imports: [RouterOutlet],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })

--- a/src/app/features/public/episode-card/episode-card.component.html
+++ b/src/app/features/public/episode-card/episode-card.component.html
@@ -27,13 +27,11 @@
 
     <div class="episode-links">
       @if (episode.spotify_url) {
-        <a [href]="episode.spotify_url" target="_blank" rel="noopener noreferrer"> 🎧 Spotify </a>
+        <a [href]="episode.spotify_url"> 🎧 Spotify </a>
       }
 
       @if (episode.apple_podcasts_url) {
-        <a [href]="episode.apple_podcasts_url" target="_blank" rel="noopener noreferrer">
-          🍎 Apple
-        </a>
+        <a [href]="episode.apple_podcasts_url"> Apple </a>
       }
 
       @if (episode.audio_url) {

--- a/src/app/features/public/episode-card/episode-card.component.html
+++ b/src/app/features/public/episode-card/episode-card.component.html
@@ -1,0 +1,50 @@
+<div class="episode-card">
+  <img
+    [src]="episode.img_url"
+    alt="{{ episode.title }} cover"
+    class="episode-image"
+    loading="lazy"
+  />
+
+  <div class="episode-content">
+    <div class="episode-header">
+      <h3 class="episode-title">{{ episode.title }}</h3>
+
+      @if (episode.featured === 'true') {
+        <span class="featured-badge" aria-label="Featured Episode">Featured</span>
+      }
+    </div>
+
+    <p class="episode-description">
+      {{ episode.description }}
+    </p>
+
+    <div class="episode-meta">
+      <span>{{ episode.season }} - Episode {{ episode.episode }}</span>
+      <span>{{ episode.duration }}</span>
+      <span>{{ episode.posted_on | date: 'mediumDate' }}</span>
+    </div>
+
+    <div class="episode-links">
+      @if (episode.spotify_url) {
+        <a [href]="episode.spotify_url" target="_blank" rel="noopener noreferrer"> 🎧 Spotify </a>
+      }
+
+      @if (episode.apple_podcasts_url) {
+        <a [href]="episode.apple_podcasts_url" target="_blank" rel="noopener noreferrer">
+          🍎 Apple
+        </a>
+      }
+
+      @if (episode.audio_url) {
+        <button
+          type="button"
+          class="episode-play-button"
+          [ngClass]="{ playing: isPlaying }"
+          (click)="onPlayClick()"
+          aria-label="Play/Pause Episode"
+        ></button>
+      }
+    </div>
+  </div>
+</div>

--- a/src/app/features/public/episode-card/episode-card.component.scss
+++ b/src/app/features/public/episode-card/episode-card.component.scss
@@ -1,0 +1,135 @@
+@use '../../../../styles/variables' as *;
+@use '../../../../styles/mixins' as *;
+
+.episode-card {
+  @include surface-style(true);
+  background-color: var(--color-background);
+  border-color: var(--color-border-subtle);
+  box-shadow: none;
+
+  @include flex(row, flex-start, flex-start, 1rem);
+  padding: 1rem;
+  border-radius: 8px;
+
+  &:hover {
+    background-color: var(--color-hover);
+  }
+
+  .episode-image {
+    width: 112px;
+    height: 112px;
+    border-radius: 8px;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .episode-content {
+    @include flex(column, flex-start, flex-start, 1rem);
+    flex-grow: 1;
+    min-width: 0;
+  }
+
+  .episode-header {
+    @include flex(column, flex-start, flex-start, 0.25rem);
+    width: 100%;
+
+    .episode-title {
+      @include TextPreset2;
+      color: var(--color-text-primary);
+      margin: 0;
+    }
+  }
+
+  .episode-description {
+    @include TextPreset5;
+    color: var(--color-text-secondary);
+    margin: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .episode-meta {
+    @include flex(row, flex-start, center, 0.5rem);
+    @include TextPreset6;
+    color: var(--color-text-secondary);
+
+    span:first-child {
+      display: none;
+    }
+
+    span:nth-child(2)::after {
+      content: '•';
+      margin-left: 0.5rem;
+      color: var(--color-text-tertiary);
+    }
+  }
+
+  .episode-links {
+    @include flex(row, space-between, center);
+    width: 100%;
+    margin-top: 0.5rem;
+
+    a {
+      display: none;
+    }
+
+    .episode-play-button {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      background-color: var(--color-text-primary);
+      color: var(--color-background);
+      font-size: 0;
+      border: none;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+
+      &:hover {
+        transform: scale(1.05);
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+      }
+
+      &::before {
+        content: '';
+        display: block;
+        width: 0;
+        height: 0;
+        border-top: 9px solid transparent;
+        border-bottom: 9px solid transparent;
+        border-left: 15px solid var(--color-background);
+        margin-left: 5px;
+      }
+
+      &.playing::before {
+        content: '';
+        width: 12px;
+        height: 16px;
+        display: flex;
+        background-color: transparent;
+        box-sizing: border-box;
+        border-left: 4px solid var(--color-background);
+        border-right: 4px solid var(--color-background);
+        margin-left: 0;
+      }
+    }
+
+    &::before {
+      content: '⊕  ↱  ⋯';
+      @include flex(row, flex-start, center, 1.5rem);
+      font-size: 0.859rem;
+      gap: 1rem;
+      color: var(--color-text-secondary);
+    }
+  }
+
+  .featured-badge {
+    display: inline-block;
+  }
+}

--- a/src/app/features/public/episode-card/episode-card.component.spec.ts
+++ b/src/app/features/public/episode-card/episode-card.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EpisodeCardComponent } from './episode-card.component';
+
+describe('EpisodeCardComponent', () => {
+  let component: EpisodeCardComponent;
+  let fixture: ComponentFixture<EpisodeCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EpisodeCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EpisodeCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/public/episode-card/episode-card.component.ts
+++ b/src/app/features/public/episode-card/episode-card.component.ts
@@ -1,0 +1,33 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Episode } from '../../../core/core.module';
+
+@Component({
+  selector: 'app-episode-card',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './episode-card.component.html',
+  styleUrls: ['./episode-card.component.scss'],
+})
+export class EpisodeCardComponent {
+  @Input() episode!: Episode;
+  isPlaying = false;
+  private audio!: HTMLAudioElement;
+
+  onPlayClick(): void {
+    if (!this.audio) {
+      this.audio = new Audio(this.episode.audio_url);
+      this.audio.addEventListener('ended', () => {
+        this.isPlaying = false;
+      });
+    }
+
+    if (this.isPlaying) {
+      this.audio.pause();
+    } else {
+      this.audio.play();
+    }
+
+    this.isPlaying = !this.isPlaying;
+  }
+}

--- a/src/app/features/public/home/home/home.component.html
+++ b/src/app/features/public/home/home/home.component.html
@@ -1,1 +1,13 @@
-<p>home works!</p>
+<section class="latest-episodes">
+  <h2>Latest Episodes</h2>
+
+  @if (episodes$ | async; as episodes) {
+    <div class="episode-list">
+      @for (episode of episodes.slice(0, 5); track episode.id) {
+        <app-episode-card [episode]="episode" />
+      }
+    </div>
+  } @else {
+    <p>Loading episodes...</p>
+  }
+</section>

--- a/src/app/features/public/home/home/home.component.scss
+++ b/src/app/features/public/home/home/home.component.scss
@@ -1,0 +1,20 @@
+@use '../../../../../styles/variables' as *;
+@use '../../../../../styles/mixins' as *;
+
+.episode-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+  padding-block: 2rem;
+  padding-inline: 1rem;
+
+  @include tablet {
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 1rem;
+  }
+
+  @include mobile {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}

--- a/src/app/features/public/home/home/home.component.ts
+++ b/src/app/features/public/home/home/home.component.ts
@@ -1,19 +1,21 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { Observable } from 'rxjs';
-import { EpisodeService } from '../../../../core/core.module';
-import { Episode } from '../../../../core/core.module';
+import { EpisodeService, Episode } from '../../../../core/core.module';
+import { EpisodeCardComponent } from '../../episode-card/episode-card.component';
+
 @Component({
   selector: 'app-home',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, EpisodeCardComponent],
   templateUrl: './home.component.html',
-  styleUrl: './home.component.scss',
+  styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
   private episodeService = inject(EpisodeService);
-  episodes$!: Observable<Episode[]>;
+  episodes$: Observable<Episode[]> = this.episodeService.episodes$;
 
   ngOnInit(): void {
-    this.episodes$ = this.episodeService.episodes$;
-    this.episodeService.getEpisodes().subscribe((data) => console.log('episodes', data));
+    this.episodeService.getEpisodes().subscribe();
   }
 }


### PR DESCRIPTION
This PR introduces the homepage section of the podcast web app, which includes:

 Features
Display latest episodes (via EpisodeService).
Standalone EpisodeCardComponent to render each episode in a consistent, styled layout.
Integrated support for the new Angular control flow syntax using @if.

Episode card includes:
Cover image
Title, description, duration, date
Spotify and Apple links (conditionally rendered)
Local audio playback button with toggling play/pause icon.
Reusable styling via SCSS variables and mixins.

